### PR TITLE
Add model scaling helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
 # Inference economics of language models
 
 This is the public repository for the "Inference economics of language models" paper. It contains a Jupyter notebook that contains the models presented in the paper and that you can use to reproduce the paper's results.
+
+The `inference_economics_notebook.py` script now includes a helper function
+`scale_model_for_cost_bandwidth` which searches for a scaling of a base model so
+that a provided cost and throughput pair lies on the model's cost-throughput
+frontier.  The function can be imported and used directly in other scripts.


### PR DESCRIPTION
## Summary
- add `scale_model_for_cost_bandwidth` helper in the notebook
- document new function in README

## Testing
- `python -m py_compile inference_economics_notebook.py`


------
https://chatgpt.com/codex/tasks/task_e_6854855f0a7083268e2555ebaefd3cb6