### PR TITLE
Fix GPT-4.1 reference in docs and helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,4 @@ frontier.  The function can be imported and used directly in other scripts.
 
 Additional helper scripts:
 - `scaled_curve_helpers.py` provides utilities to scale a model so that it matches a desired cost/throughput pair and to plot cost-throughput curves.
-- `generate_scaled_curves.py` demonstrates how to scale DeepSeek_V3, Llama 3 405B and GPT-4 to pass through the GPT‑4o API point (110 tok/s, 8 USD per million tokens) and writes the resulting scalings to `gpt4o_scalings.txt`.
+- `generate_scaled_curves.py` demonstrates how to scale DeepSeek_V3, Llama 3 405B and GPT-4 to pass through the GPT-4.1 API point (110 tok/s, 8 USD per million tokens) and writes the resulting scalings to `gpt4o_scalings.txt`.

--- a/scaled_curve_helpers.py
+++ b/scaled_curve_helpers.py
@@ -13,7 +13,7 @@ from inference_economics_notebook import (
 
 
 def scale_to_gpt4o(model):
-    """Scale ``model`` so that the GPT-4o price/perf point lies on its frontier.
+    """Scale ``model`` so that the GPT-4.1 price/perf point lies on its frontier.
     Returns the scaled model and scaling factor."""
     scaled = scale_model_for_cost_bandwidth(
         target_cost=8.0,
@@ -36,7 +36,7 @@ def plot_curves(curve_data, output_file="gpt4o_scaled_curves.png"):
     plt.figure(figsize=(8, 6))
     for name, (x, y, color) in curve_data.items():
         plt.plot(x, y, label=name, color=color)
-    plt.scatter([110], [8], color="black", label="GPT-4o API")
+    plt.scatter([110], [8], color="black", label="GPT-4.1 API")
     plt.xlabel("Tokens per second per request")
     plt.ylabel("Cost per million tokens (USD)")
     plt.yscale("log")


### PR DESCRIPTION
## Summary
- update README example to reference GPT-4.1
- update helper docstring and plot label to GPT-4.1

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_68549255d1c08326bc117de1678ce4f5