### PR TITLE
Add progress bars for generating scaled curves

### DIFF
--- a/generate_scaled_curves.py
+++ b/generate_scaled_curves.py
@@ -1,6 +1,12 @@
 from scaled_curve_helpers import scale_to_gpt4o, curve_for_model, plot_curves
 from inference_economics_notebook import DeepSeek_V3, Llama_3_405B, GPT_4
 
+try:
+    from tqdm.auto import tqdm
+except ImportError:  # pragma: no cover - optional dependency
+    def tqdm(x, *args, **kwargs):
+        return x
+
 models = {
     "DeepSeek_V3": (DeepSeek_V3, "red"),
     "Llama 3 405B": (Llama_3_405B, "blue"),
@@ -9,7 +15,7 @@ models = {
 
 scaled_info = {}
 scalings = {}
-for name, (model, color) in models.items():
+for name, (model, color) in tqdm(models.items(), desc="Models"):
     scaled, factor = scale_to_gpt4o(model)
     scalings[name] = (factor, scaled.total_params)
     x, y = curve_for_model(scaled, name, color)

--- a/inference_economics_notebook.py
+++ b/inference_economics_notebook.py
@@ -16,6 +16,12 @@ from typing import Callable
 from copy import deepcopy
 import matplotlib.cm as cm
 
+try:
+    from tqdm.auto import tqdm
+except ImportError:  # pragma: no cover - tqdm is optional
+    def tqdm(x, *args, **kwargs):
+        return x
+
 # ## Language model and GPU definitions
 # 
 # This section contains a transformer class and a GPU class, along with object definitions for important models and GPUs. Details such as whether a GPU should be assumed to have a kernel launch latency or what the latency structure of GPU collectives is like are also handled here.
@@ -1451,9 +1457,12 @@ def pareto_fronts(comparison_list: list[TokenEconSettings], token_latency_second
     gpu_counts = []
     batch_sizes = []
 
-    token_latency_seconds_range = np.min(token_latency_seconds_array) * np.logspace(0, 2, base=10, num=1000) # ranges from max speed/100 to max speed
+    token_latency_seconds_range = np.min(token_latency_seconds_array) * np.logspace(0, 2, base=10, num=1000)  # ranges from max speed/100 to max speed
 
-    for token_latency_seconds_sample in token_latency_seconds_range:
+    for token_latency_seconds_sample in tqdm(
+        token_latency_seconds_range,
+        desc=f"Pareto {comparison_setting.name}",
+    ):
       indices = np.where((token_latency_seconds_array <= token_latency_seconds_sample) & (batch_size_array/token_latency_seconds_array <= max_throughput_tokens_per_second))
       if len(indices[0]) > 0:
         minimal_cost = np.min(gpu_seconds_per_token[indices])


### PR DESCRIPTION
## Summary
- show progress while scaling models and computing Pareto fronts
- provide tqdm fallback when the package isn't installed

## Testing
- `python -m py_compile generate_scaled_curves.py inference_economics_notebook.py scaled_curve_helpers.py`

------
https://chatgpt.com/codex/tasks/task_e_685493aa26248326bb4bde2f44fc6784