### PR TITLE
Add global progress bar to generate_scaled_curves

### DIFF
--- a/generate_scaled_curves.py
+++ b/generate_scaled_curves.py
@@ -15,11 +15,22 @@ models = {
 
 scaled_info = {}
 scalings = {}
+
+# ``pareto_fronts`` iterates over 1000 samples for each model. Use this value
+# to build an overall progress bar across all models.
+TOTAL_ITERATIONS_PER_MODEL = 1000
+overall_progress = tqdm(
+    total=TOTAL_ITERATIONS_PER_MODEL * len(models),
+    desc="Overall progress",
+)
+
 for name, (model, color) in tqdm(models.items(), desc="Models"):
     scaled, factor = scale_to_gpt4o(model)
     scalings[name] = (factor, scaled.total_params)
-    x, y = curve_for_model(scaled, name, color)
+    x, y = curve_for_model(scaled, name, color, overall_progress)
     scaled_info[name] = (x, y, color)
+
+overall_progress.close()
 
 plot_curves(scaled_info)
 

--- a/scaled_curve_helpers.py
+++ b/scaled_curve_helpers.py
@@ -25,10 +25,21 @@ def scale_to_gpt4o(model):
     return scaled, scale_factor
 
 
-def curve_for_model(model, name, color):
+def curve_for_model(model, name, color, overall_progress=None):
+    """Return the cost/throughput curve for ``model``.
+
+    If ``overall_progress`` is provided, it will be updated by
+    :func:`pareto_fronts` to allow tracking progress across multiple models.
+    """
+
     settings = [TokenEconSettings(name=name, gpu=H100, model=model, input_len=0, color=color)]
     comp = ComparisonSettings(settings, "tmp", "tmp")
-    x, y, _, _, _ = pareto_fronts(comp.comparison_list, token_latency_seconds_default, use_pp=True)[0]
+    x, y, _, _, _ = pareto_fronts(
+        comp.comparison_list,
+        token_latency_seconds_default,
+        use_pp=True,
+        overall_progress=overall_progress,
+    )[0]
     return x, y
 
 


### PR DESCRIPTION
## Summary
- allow `pareto_fronts` to accept an external progress bar
- update `curve_for_model` to pass this progress bar through
- add an overall progress bar in `generate_scaled_curves` that spans all models

## Testing
- `python -m py_compile generate_scaled_curves.py scaled_curve_helpers.py inference_economics_notebook.py`

------
https://chatgpt.com/codex/tasks/task_e_685499e5bd6c8326b77162761b58e50c