### PR TITLE
Add iterations parameter to curve generation

### DIFF
--- a/generate_scaled_curves.py
+++ b/generate_scaled_curves.py
@@ -1,5 +1,6 @@
 from scaled_curve_helpers import scale_to_gpt4o, curve_for_model, plot_curves
 from inference_economics_notebook import DeepSeek_V3, Llama_3_405B, GPT_4
+import argparse
 
 try:
     from tqdm.auto import tqdm
@@ -13,27 +14,47 @@ models = {
     "GPT-4": (GPT_4, "green"),
 }
 
-scaled_info = {}
-scalings = {}
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate cost/throughput curves")
+    parser.add_argument(
+        "--iterations",
+        type=int,
+        default=1000,
+        help="Number of samples to use when computing Pareto fronts",
+    )
+    args = parser.parse_args()
 
-# ``pareto_fronts`` iterates over 1000 samples for each model. Use this value
-# to build an overall progress bar across all models.
-TOTAL_ITERATIONS_PER_MODEL = 1000
-overall_progress = tqdm(
-    total=TOTAL_ITERATIONS_PER_MODEL * len(models),
-    desc="Overall progress",
-)
+    scaled_info = {}
+    scalings = {}
 
-for name, (model, color) in tqdm(models.items(), desc="Models"):
-    scaled, factor = scale_to_gpt4o(model)
-    scalings[name] = (factor, scaled.total_params)
-    x, y = curve_for_model(scaled, name, color, overall_progress)
-    scaled_info[name] = (x, y, color)
+    iterations_per_model = args.iterations
+    overall_progress = tqdm(
+        total=iterations_per_model * len(models),
+        desc="Overall progress",
+    )
 
-overall_progress.close()
+    for name, (model, color) in tqdm(models.items(), desc="Models"):
+        scaled, factor = scale_to_gpt4o(model)
+        scalings[name] = (factor, scaled.total_params)
+        x, y = curve_for_model(
+            scaled,
+            name,
+            color,
+            overall_progress=overall_progress,
+            num_iterations=iterations_per_model,
+        )
+        scaled_info[name] = (x, y, color)
 
-plot_curves(scaled_info)
+    overall_progress.close()
 
-with open("gpt4o_scalings.txt", "w") as f:
-    for name, (factor, params) in scalings.items():
-        f.write(f"{name}: scale factor {factor:.3f}, total params {params/1e9:.2f}B\n")
+    plot_curves(scaled_info)
+
+    with open("gpt4o_scalings.txt", "w") as f:
+        for name, (factor, params) in scalings.items():
+            f.write(
+                f"{name}: scale factor {factor:.3f}, total params {params/1e9:.2f}B\n"
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/inference_economics_notebook.py
+++ b/inference_economics_notebook.py
@@ -1429,16 +1429,20 @@ def pareto_fronts(
     token_latency_seconds_func,
     use_pp: bool = False,
     overall_progress=None,
+    num_iterations: int = 1000,
 ):
   """Compute Pareto fronts for ``comparison_list``.
 
   If ``overall_progress`` is ``None`` a new :class:`tqdm` progress bar is
   created. Otherwise, the provided progress bar is updated.
+
+  ``num_iterations`` specifies how many sample points to evaluate for each
+  comparison, trading off accuracy for runtime.
   """
 
   token_economics_results = []
 
-  total_iterations = len(comparison_list) * 1000  # each comparison uses 1000 samples
+  total_iterations = len(comparison_list) * num_iterations  # each comparison uses num_iterations samples
   owns_progress = overall_progress is None
   if owns_progress:
     overall_progress = tqdm(total=total_iterations, desc="Overall progress", position=0)
@@ -1473,7 +1477,12 @@ def pareto_fronts(
     gpu_counts = []
     batch_sizes = []
 
-    token_latency_seconds_range = np.min(token_latency_seconds_array) * np.logspace(0, 2, base=10, num=1000)  # ranges from max speed/100 to max speed
+    token_latency_seconds_range = np.min(token_latency_seconds_array) * np.logspace(
+        0,
+        2,
+        base=10,
+        num=num_iterations,
+    )  # ranges from max speed/100 to max speed
 
     for token_latency_seconds_sample in tqdm(
         token_latency_seconds_range,

--- a/scaled_curve_helpers.py
+++ b/scaled_curve_helpers.py
@@ -25,11 +25,19 @@ def scale_to_gpt4o(model):
     return scaled, scale_factor
 
 
-def curve_for_model(model, name, color, overall_progress=None):
+def curve_for_model(
+    model,
+    name,
+    color,
+    overall_progress=None,
+    num_iterations=1000,
+):
     """Return the cost/throughput curve for ``model``.
 
     If ``overall_progress`` is provided, it will be updated by
     :func:`pareto_fronts` to allow tracking progress across multiple models.
+    ``num_iterations`` controls how many samples :func:`pareto_fronts` uses,
+    trading off accuracy for runtime.
     """
 
     settings = [TokenEconSettings(name=name, gpu=H100, model=model, input_len=0, color=color)]
@@ -39,6 +47,7 @@ def curve_for_model(model, name, color, overall_progress=None):
         token_latency_seconds_default,
         use_pp=True,
         overall_progress=overall_progress,
+        num_iterations=num_iterations,
     )[0]
     return x, y
 


### PR DESCRIPTION
## Summary
- allow tuning performance of pareto front search
- add `--iterations` CLI option to `generate_scaled_curves.py`
- forward iteration count through `curve_for_model`
- support iteration count in `pareto_fronts`

## Testing
- `python3 -m py_compile generate_scaled_curves.py scaled_curve_helpers.py inference_economics_notebook.py`
- `pip install -r requirements.txt`
- `python3 generate_scaled_curves.py --help`
- *(interrupted)* `python3 generate_scaled_curves.py --iterations 1`

------
https://chatgpt.com/codex/tasks/task_e_68549b0900688326b1bbff938651fb04