### PR TITLE
Add speed controls for scaled curve generation

### DIFF
--- a/generate_scaled_curves.py
+++ b/generate_scaled_curves.py
@@ -22,6 +22,12 @@ def main() -> None:
         default=1000,
         help="Number of samples to use when computing Pareto fronts",
     )
+    parser.add_argument(
+        "--grid-size",
+        type=int,
+        default=400,
+        help="Resolution of batch size/GPU count search grid",
+    )
     args = parser.parse_args()
 
     scaled_info = {}
@@ -34,7 +40,11 @@ def main() -> None:
     )
 
     for name, (model, color) in tqdm(models.items(), desc="Models"):
-        scaled, factor = scale_to_gpt4o(model)
+        scaled, factor = scale_to_gpt4o(
+            model,
+            num_iterations=iterations_per_model,
+            grid_size=args.grid_size,
+        )
         scalings[name] = (factor, scaled.total_params)
         x, y = curve_for_model(
             scaled,
@@ -42,6 +52,7 @@ def main() -> None:
             color,
             overall_progress=overall_progress,
             num_iterations=iterations_per_model,
+            grid_size=args.grid_size,
         )
         scaled_info[name] = (x, y, color)
 

--- a/scaled_curve_helpers.py
+++ b/scaled_curve_helpers.py
@@ -12,7 +12,7 @@ from inference_economics_notebook import (
 )
 
 
-def scale_to_gpt4o(model):
+def scale_to_gpt4o(model, *, num_iterations=1000, grid_size=400):
     """Scale ``model`` so that the GPT-4.1 price/perf point lies on its frontier.
     Returns the scaled model and scaling factor."""
     scaled = scale_model_for_cost_bandwidth(
@@ -20,6 +20,8 @@ def scale_to_gpt4o(model):
         target_tokens_per_second=110.0,
         base_model=model,
         gpu=H100,
+        num_iterations=num_iterations,
+        grid_size=grid_size,
     )
     scale_factor = scaled.total_params / model.total_params
     return scaled, scale_factor
@@ -31,13 +33,15 @@ def curve_for_model(
     color,
     overall_progress=None,
     num_iterations=1000,
+    grid_size=400,
 ):
     """Return the cost/throughput curve for ``model``.
 
     If ``overall_progress`` is provided, it will be updated by
     :func:`pareto_fronts` to allow tracking progress across multiple models.
     ``num_iterations`` controls how many samples :func:`pareto_fronts` uses,
-    trading off accuracy for runtime.
+    trading off accuracy for runtime. ``grid_size`` sets the resolution of the
+    search space for batch size and GPU count.
     """
 
     settings = [TokenEconSettings(name=name, gpu=H100, model=model, input_len=0, color=color)]
@@ -48,6 +52,7 @@ def curve_for_model(
         use_pp=True,
         overall_progress=overall_progress,
         num_iterations=num_iterations,
+        grid_size=grid_size,
     )[0]
     return x, y
 


### PR DESCRIPTION
## Summary
- add `--grid-size` CLI arg to adjust Pareto search resolution
- plumb `grid_size` and `num_iterations` through helper functions
- allow configuring `scale_model_for_cost_bandwidth` sampling
- cap scale search iterations for faster convergence

## Testing
- `pip install -r requirements.txt`
- `python generate_scaled_curves.py --iterations 10 --grid-size 50`

------
https://chatgpt.com/codex/tasks/task_e_68549efcaefc832686a1f4dbed83dab1